### PR TITLE
msm8974-common: Symlink bootdevice for Lineage Recovery

### DIFF
--- a/recovery/root/init.recovery.qcom.rc
+++ b/recovery/root/init.recovery.qcom.rc
@@ -1,4 +1,7 @@
 on fs
+    wait /dev/block/platform/msm_sdcc.1
+    symlink /dev/block/platform/msm_sdcc.1 /dev/block/bootdevice
+
     setprop sys.usb.ffs.aio_compat 1
     setprop persist.adb.nonblocking_ffs 0
     setprop ro.adb.nonblocking_ffs 0


### PR DESCRIPTION
* It is needed by OpenGApps install script.

Change-Id: Idb90a6ecaae541e74a9878c1ca93459cc2fdd949